### PR TITLE
Use safe_load_all to detect errors in multi-document files. Fixes #1

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -33,7 +33,9 @@ class Pyyaml(PythonLinter):
         yaml = self.module
 
         try:
-            yaml.safe_load(code)
+            for x in yaml.safe_load_all(code):
+                # exhausting generator so all documents are checked
+                pass
         except yaml.error.YAMLError as exc:
             if persist.settings.get('debug'):
                 persist.printf('{} - {} : {}'.format(self.name, type(exc), exc))


### PR DESCRIPTION
Test document:

``` yaml
a: okay

---
b: {{ad}}
```

Should fail with `ConstructorError: 'found unhashable key while constructing map'`, rather than `ComposerError` as before.

Still works fine with single-document files.
